### PR TITLE
- DownloadReport does not allow to write output to binary files opened in mode other than "wb"

### DIFF
--- a/googleads/adwords.py
+++ b/googleads/adwords.py
@@ -382,6 +382,12 @@ class ReportDownloader(object):
         (self._REPORT_DEFINITION_NAME, self._namespace)]
     self._marshaller = suds.mx.literal.Literal(schema)
 
+  def _DownloadReportCheckFormat(self, file_format, output):
+    if (file_format.startswith('GZIPPED_')
+        and not 'b' in getattr(output, 'mode', 'w')):
+      raise googleads.errors.GoogleAdsValueError('Need to specify a binary'
+                                                 ' output for GZIPPED formats.')
+
   def DownloadReport(self, report_definition, output=sys.stdout,
                      return_money_in_micros=None):
     """Downloads an AdWords report using a report definition.
@@ -408,11 +414,7 @@ class ReportDownloader(object):
       AdWordsReportError: if the request fails for any other reason; e.g. a
           network error.
     """
-    if (report_definition['downloadFormat'].startswith('GZIPPED_')
-        and getattr(output, 'mode', 'w') != 'wb'):
-      raise googleads.errors.GoogleAdsValueError('Need to specify a binary'
-                                                 ' output for GZIPPED formats.')
-
+    self._DownloadReportCheckFormat(report_definition['downloadFormat'], output)
     self._DownloadReport(self._SerializeReportDefinition(report_definition),
                          output, return_money_in_micros)
 
@@ -444,11 +446,7 @@ class ReportDownloader(object):
       AdWordsReportError: if the request fails for any other reason; e.g. a
           network error.
     """
-    if (file_format.startswith('GZIPPED_')
-        and getattr(output, 'mode', 'w') != 'wb'):
-      raise googleads.errors.GoogleAdsValueError('Need to specify a binary'
-                                                 ' output for GZIPPED formats.')
-
+    self._DownloadReportCheckFormat(file_format, output)
     self._DownloadReport(self._SerializeAwql(query, file_format), output,
                          return_money_in_micros)
 


### PR DESCRIPTION
Fixed.
