### PR TITLE
Remove typo tuple-casting the query string

### DIFF
--- a/examples/dfp/v201405/custom_targeting_service/get_custom_targeting_keys_by_statement.py
+++ b/examples/dfp/v201405/custom_targeting_service/get_custom_targeting_keys_by_statement.py
@@ -38,7 +38,7 @@ def main(client):
           'value': 'PREDEFINED'
       }
   }]
-  query = 'WHERE type = :type',
+  query = 'WHERE type = :type'
   statement = dfp.FilterStatement(query, values)
 
   # Get custom targeting keys by statement.


### PR DESCRIPTION
When running the `get_custom_targeting_keys_by_statement` module it raises an exception:

```
suds.WebFault: Server raised fault: '[PublisherQueryLanguageSyntaxError.UNPARSABLE @ Unable to     parse query: '('WHERE type = :type',) LIMIT 500 OFFSET 0'
Syntax error at line 1, column 1.
Extraneous input: '('.]'
```

A quick grep didn't indicate it elsewhere in the examples dir.
