### PR TITLE
Fix the action key for the Audience Segment populate example

### DIFF
--- a/examples/dfp/v201405/audience_segment_service/populate_first_party_audience_segments.py
+++ b/examples/dfp/v201405/audience_segment_service/populate_first_party_audience_segments.py
@@ -65,7 +65,7 @@ def main(client, audience_segment_id):
              % (segment['id'], segment['name']))
 
     action = {
-        'AudienceSegmentAction.Type': 'PopulateAudienceSegments'
+        'xsi_type': 'PopulateAudienceSegments'
     }
 
     populated_audience_segments = (


### PR DESCRIPTION
This is related to #18 as reported by @tly1980

I ran in to the same issue. This patch performs the Populate request correctly (confirmed in the Audience segment's History in the DFP site).