### PR TITLE
HTTP header "Authorization" is missing when https_proxy is set in the yaml config.

### DIFF
--- a/googleads/oauth2.py
+++ b/googleads/oauth2.py
@@ -113,10 +113,15 @@ class GoogleRefreshTokenClient(GoogleOAuth2Client):
       try:
         request = urllib2.Request(self._GOOGLE_OAUTH2_ENDPOINT, post_body,
                                   self._OAUTH2_REFRESH_HEADERS)
+
         if self.https_proxy:
-          request.set_proxy(self.https_proxy, 'https')
+          proxy_support = urllib2.ProxyHandler({'https': self.https_proxy})
+          opener = urllib2.build_opener(proxy_support)
+        else:
+          opener = urllib2.build_opener()
+
         # Need to decode the content - in Python 3 it's bytes, not a string.
-        content = urllib2.urlopen(request).read().decode()
+        content = opener.open(request).read().decode()
         self._oauthlib_client.parse_request_body_response(content)
         _, oauth2_header, _ = self._oauthlib_client.add_token(self._TOKEN_URL)
       except Exception, e:


### PR DESCRIPTION
I use following code to initiate the DFP client, it works just fine if I don't need proxy server.

```
def dfp_client(auth_file='./auth.yaml'):
    client = dfp.DfpClient.LoadFromStorage(auth_file)
    return client

client = dfp_client()
li_service = client.GetService('LineItemService', version='v201403')
...
...
```

However, the code breaks when the proxy server is set in auth.yaml

```
dfp:
  application_name: Awesome App
  client_id: MYCLIENT_ID
  client_secret: MYCLIENT_SECRET
  refresh_token: MYREFRESH_TOKEN
  network_code: 1234
  https_proxy: 'http://localhost:8888'
```

The error I've got is:
`suds.WebFault: Server raised fault: '[AuthenticationError.MISSING_AUTHENTICATION @ ]'`

And then I set the logging level to DEBUG, and I can see "Authorization" is missing in the suds.client headers.  "Authorization" header was there if I disable the proxy.

```
DEBUG:suds.client:headers = {'SOAPAction': '""', 'Content-Type': 'text/xml; charset=utf-8'}
DEBUG:suds.transport.http:sending:
URL: https://www.google.com/apis/ads/publisher/v201403/LineItemService
HEADERS: {'SOAPAction': '""', 'Content-Type': 'text/xml; charset=utf-8', 'Content-type': 'text/xml; charset=utf-8', 'Soapaction': '""'}
MESSAGE:
<?xml version="1.0" encoding="UTF-8"?><SOAP-ENV:Envelope xmlns:ns0="https://www.google.com/apis/ads/publisher/v201403" xmlns:ns1="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:tns="https://www.google.com/apis/ads/publisher/v201403" xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"><SOAP-ENV:Header><tns:RequestHeader><tns:networkCode>5129</tns:networkCode><tns:applicationName>Awesome App (DfpApi-Python, googleads/1.0.6, Python/2.7)</tns:applicationName></tns:RequestHeader></SOAP-ENV:Header><ns1:Body><ns0:getLineItemsByStatement><ns0:filterStatement><ns0:query>WHERE id = :id LIMIT 500 OFFSET 0</ns0:query><ns0:values><ns0:key>id</ns0:key><ns0:value xsi:type="ns0:TextValue"><ns0:Value.Type>TextValue</ns0:Value.Type><ns0:value>155559071</ns0:value></ns0:value></ns0:values></ns0:filterStatement></ns0:getLineItemsByStatement></ns1:Body></SOAP-ENV:Envelope>
DEBUG:suds.client:HTTP failed - 500 - Internal Server Error:
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><soap:Fault><faultcode>soap:Server</faultcode><faultstring>[AuthenticationError.MISSING_AUTHENTICATION @ ]</faultstring><detail><ApiExceptionFault xmlns="https://www.google.com/apis/ads/publisher/v201403"><message>[AuthenticationError.MISSING_AUTHENTICATION @ ]</message><ApplicationException.Type>ApiException</ApplicationException.Type><errors xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AuthenticationError"><fieldPath></fieldPath><trigger></trigger><errorString>AuthenticationError.MISSING_AUTHENTICATION</errorString><ApiError.Type>AuthenticationError</ApiError.Type><reason>MISSING_AUTHENTICATION</reason></errors></ApiExceptionFault></detail></soap:Fault></soap:Body></soap:Envelope>
DEBUG:suds.metrics:<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><soap:Fault><faultcode>soap:Server</faultcode><faultstring>[AuthenticationError.MISSING_AUTHENTICATION @ ]</faultstring><detail><ApiExceptionFault xmlns="https://www.google.com/apis/ads/publisher/v201403"><message>[AuthenticationError.MISSING_AUTHENTICATION @ ]</message><ApplicationException.Type>ApiException</ApplicationException.Type><errors xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="AuthenticationError"><fieldPath></fieldPath><trigger></trigger><errorString>AuthenticationError.MISSING_AUTHENTICATION</errorString><ApiError.Type>AuthenticationError</ApiError.Type><reason>MISSING_AUTHENTICATION</reason></errors></ApiExceptionFault></detail></soap:Fault></soap:Body></soap:Envelope>
sax duration: 1 (ms)
```
