### PR TITLE
Handle and raise OAuth errors

### DIFF
--- a/googleads/errors.py
+++ b/googleads/errors.py
@@ -22,6 +22,38 @@ class GoogleAdsError(Exception):
   pass
 
 
+class OAuthError(GoogleAdsError):
+  """Parent class of all OAuth related errors."""
+
+
+class OAuthInvalidRequestError(OAuthError):
+  """The request is incomplete or malformed."""
+
+
+class OAuthInvalidGrantError(OAuthError):
+  """The grant  or refresh token is invalid."""
+
+
+class OAuthInvalidClientError(OAuthError):
+  """Client authentication failed."""
+
+
+class OAuthInvalidScopeError(OAuthError):
+  """The requested scope is invalid."""
+
+
+class OAuthUnauthorizedClientError(OAuthError):
+  """The client is not authorized to use this authorization grant type."""
+
+
+class OAuthUnsupportedGrantTypeError(OAuthError):
+  """The grant type is not supported by the authorization server."""
+
+
+class OAuthUnknownError(OAuthError):
+  """An unknown, unhandled OAuth error occured."""
+
+
 class GoogleAdsValueError(GoogleAdsError):
   """Error indicating that the user input for a function was invalid."""
   pass

--- a/googleads/errors.py
+++ b/googleads/errors.py
@@ -50,6 +50,10 @@ class OAuthUnsupportedGrantTypeError(OAuthError):
   """The grant type is not supported by the authorization server."""
 
 
+class OAuthTemporaryServerError(OAuthError):
+    """The server could temporarily not handle the request. Please retry."""
+
+
 class OAuthUnknownError(OAuthError):
   """An unknown, unhandled OAuth error occured."""
 

--- a/googleads/oauth2.py
+++ b/googleads/oauth2.py
@@ -97,9 +97,16 @@ class GoogleRefreshTokenClient(GoogleOAuth2Client):
 
     Always raises an exception. Which one depends on the OAuth error code in
     the response body.
+
+    The error param is should be of type urllib2.HTTPError.
     """
 
     error_str = u'{}'.format(error)
+
+    # Most server errors are only temporary and may very well be successful
+    # upon retry.
+    if int(error.code) in (500, 502, 503, 504):
+        raise errors.OAuthTemporaryServerError(error_str)
 
     # HTTPError instances have a read() method when it was given a file-object,
     # i.e. a response body is available.


### PR DESCRIPTION
The current CreateHttpHeader implementation silently omits the Authorization
header when fetching an access token with the refresh token fails.

This commit introduces basic error handling for failed OAuth requests. It
maps the error string from the response body to an exception type.

On a side note, I wonder why the oauth lib doesn't do this. Maybe we should
consider using a different implementation that properly handles OAuth errors
for us, instead of re-implementing stuff from the OAuth RFC.