### PR TITLE
Replace "string" with "stream" in description

### DIFF
--- a/examples/adwords/v201506/reporting/download_criteria_report_as_stream_with_awql.py
+++ b/examples/adwords/v201506/reporting/download_criteria_report_as_stream_with_awql.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This example downloads a criteria performance report as a string with AWQL.
+"""This example downloads a criteria performance report as a stream with AWQL.
 
 To get report fields, run get_report_fields.py.
 


### PR DESCRIPTION
Other examples download a report as a string. This example downloads it as a stream
