### PR TITLE
Fixed capitalization error on makeTestNetwork

### DIFF
--- a/examples/dfp/v201508/network_service/make_test_network.py
+++ b/examples/dfp/v201508/network_service/make_test_network.py
@@ -37,7 +37,7 @@ def main(client):
   network_service = client.GetService('NetworkService', version='v201508')
 
   # Create a test network.
-  network = network_service.MakeTestNetwork()
+  network = network_service.makeTestNetwork()
 
   # Display results.
   print ('Test network with network code \'%s\' and display name \'%s\' '


### PR DESCRIPTION
This example failed because the method should be makeTestNetwork, not MakeTestNetwork.
