### PR TITLE
Fixed get_ad_unit_hierarchy.py

### DIFF
--- a/examples/dfp/v201511/inventory_service/get_ad_unit_hierarchy.py
+++ b/examples/dfp/v201511/inventory_service/get_ad_unit_hierarchy.py
@@ -52,7 +52,7 @@ def main(client):
   root_statement = dfp.FilterStatement(query)
   response = inventory_service.getAdUnitsByStatement(
       root_statement.ToStatement())
-  root_ad_unit = response['results']
+  root_ad_unit = response['results'][0]
 
   if root_ad_unit:
     BuildAndDisplayAdUnitTree(root_ad_unit, all_ad_units)


### PR DESCRIPTION
When you store the parent ad unit on the variable `root_ad_unit` (line 55), you are actually storing an array of size 1 which contains the ad unit. That causes the code to fail at line 74 (`if root_ad_unit['id'] in ad_unit_tree:`), because `root_ad_unit` is not the object itself, is the array of size 1 containing the object.

To prevent that, I've added a [0] at line 55 so you are storing the object instead an array.
