### PR TITLE
Add AdGroupExtensionSettingOperation to _OPERATION_MAP dictionary (Issue #158)

### DIFF
--- a/googleads/adwords.py
+++ b/googleads/adwords.py
@@ -588,6 +588,9 @@ class BatchJobHelper(object):
         'AdGroupCriterionLabelOperation': _OPERATION(
             'AdGroupCriterionLabelOperation', 'AdGroupCriterionService',
             'mutateLabel'),
+        'AdGroupExtensionSettingOperation': _OPERATION(
+            'AdGroupExtensionSettingOperation', 'AdGroupExtensionSettingService',
+            'mutate'),
         'AdGroupOperation': _OPERATION('AdGroupOperation', 'AdGroupService',
                                        'mutate'),
         'AdGroupLabelOperation': _OPERATION('AdGroupLabelOperation',


### PR DESCRIPTION
Adding these lines to the OPERATION_MAP dictionary fixed #158 to use AdGroupExtensionSettingOperation with Batch Jobs.

I needed this fix to update multiple price extensions using batch job services.