### PR TITLE
Fix to make generate_refresh_token.py support python 3.6

### DIFF
--- a/examples/adwords/authentication/generate_refresh_token.py
+++ b/examples/adwords/authentication/generate_refresh_token.py
@@ -55,13 +55,13 @@ def main(client_id, client_secret, scopes):
 
   print ('Log into the Google Account you use to access your AdWords account'
          'and go to the following URL: \n%s\n' % (authorize_url))
-  print 'After approving the token enter the verification code (if specified).'
+  print ('After approving the token enter the verification code (if specified).')
   code = raw_input('Code: ').strip()
 
   try:
     credential = flow.step2_exchange(code)
-  except client.FlowExchangeError, e:
-    print 'Authentication has failed: %s' % e
+  except client.FlowExchangeError as e:
+    print ('Authentication has failed: %s' % e)
     sys.exit(1)
   else:
     print ('OAuth2 authorization successful!\n\n'

--- a/examples/adwords/authentication/generate_refresh_token.py
+++ b/examples/adwords/authentication/generate_refresh_token.py
@@ -56,7 +56,13 @@ def main(client_id, client_secret, scopes):
   print ('Log into the Google Account you use to access your AdWords account'
          'and go to the following URL: \n%s\n' % (authorize_url))
   print ('After approving the token enter the verification code (if specified).')
-  code = raw_input('Code: ').strip()
+
+  # fix: python3 raw_input is not defined
+  code = ''
+  try:
+    code = raw_input('Code: ').strip()
+  except NameError:
+    code = input('Code: ').strip()
 
   try:
     credential = flow.step2_exchange(code)


### PR DESCRIPTION
I got an error the following and fixed it.

```
% python --version
Python 3.6.3
% python ./examples/adwords/authentication/generate_refresh_token.py --help
  File "./examples/adwords/authentication/generate_refresh_token.py", line 58
    print 'After approving the token enter the verification code (if specified).'
                                                                                ^
SyntaxError: invalid syntax
```