### PR TITLE
Confirm batch_job status is 'DONE'

### DIFF
--- a/examples/adwords/v201802/campaign_management/add_complete_campaigns_using_batch_job.py
+++ b/examples/adwords/v201802/campaign_management/add_complete_campaigns_using_batch_job.py
@@ -391,6 +391,7 @@ def GetBatchJobDownloadUrlWhenReady(client, batch_job_id,
     batch_job = GetBatchJob(client, batch_job_id)
     poll_attempt += 1
 
+  if batch_job['status'] == 'DONE':
     if 'downloadUrl' in batch_job:
       url = batch_job['downloadUrl']['url']
       print ('Batch Job with Id "%s", Status "%s", and DownloadUrl "%s" ready.'

--- a/examples/adwords/v201802/campaign_management/add_keywords_using_incremental_batch_job.py
+++ b/examples/adwords/v201802/campaign_management/add_keywords_using_incremental_batch_job.py
@@ -218,6 +218,7 @@ def GetBatchJobDownloadUrlWhenReady(client, batch_job_id,
     batch_job = GetBatchJob(client, batch_job_id)
     poll_attempt += 1
 
+  if batch_job['status'] == 'DONE':
     if 'downloadUrl' in batch_job:
       url = batch_job['downloadUrl']['url']
       print ('Batch Job with Id "%s", Status "%s", and DownloadUrl "%s" ready.'

--- a/examples/adwords/v201806/campaign_management/add_complete_campaigns_using_batch_job.py
+++ b/examples/adwords/v201806/campaign_management/add_complete_campaigns_using_batch_job.py
@@ -391,6 +391,7 @@ def GetBatchJobDownloadUrlWhenReady(client, batch_job_id,
     batch_job = GetBatchJob(client, batch_job_id)
     poll_attempt += 1
 
+  if batch_job['status'] == 'DONE':
     if 'downloadUrl' in batch_job:
       url = batch_job['downloadUrl']['url']
       print ('Batch Job with Id "%s", Status "%s", and DownloadUrl "%s" ready.'

--- a/examples/adwords/v201806/campaign_management/add_keywords_using_incremental_batch_job.py
+++ b/examples/adwords/v201806/campaign_management/add_keywords_using_incremental_batch_job.py
@@ -218,6 +218,7 @@ def GetBatchJobDownloadUrlWhenReady(client, batch_job_id,
     batch_job = GetBatchJob(client, batch_job_id)
     poll_attempt += 1
 
+  if batch_job['status'] == 'DONE':
     if 'downloadUrl' in batch_job:
       url = batch_job['downloadUrl']['url']
       print ('Batch Job with Id "%s", Status "%s", and DownloadUrl "%s" ready.'

--- a/examples/adwords/v201809/campaign_management/add_complete_campaigns_using_batch_job.py
+++ b/examples/adwords/v201809/campaign_management/add_complete_campaigns_using_batch_job.py
@@ -391,6 +391,7 @@ def GetBatchJobDownloadUrlWhenReady(client, batch_job_id,
     batch_job = GetBatchJob(client, batch_job_id)
     poll_attempt += 1
 
+  if batch_job['status'] == 'DONE':
     if 'downloadUrl' in batch_job:
       url = batch_job['downloadUrl']['url']
       print ('Batch Job with Id "%s", Status "%s", and DownloadUrl "%s" ready.'

--- a/examples/adwords/v201809/campaign_management/add_keywords_using_incremental_batch_job.py
+++ b/examples/adwords/v201809/campaign_management/add_keywords_using_incremental_batch_job.py
@@ -218,6 +218,7 @@ def GetBatchJobDownloadUrlWhenReady(client, batch_job_id,
     batch_job = GetBatchJob(client, batch_job_id)
     poll_attempt += 1
 
+  if batch_job['status'] == 'DONE':
     if 'downloadUrl' in batch_job:
       url = batch_job['downloadUrl']['url']
       print ('Batch Job with Id "%s", Status "%s", and DownloadUrl "%s" ready.'


### PR DESCRIPTION
Explicitly confirm batch_job status is 'DONE' before accessing downloadUrl.
This may provide examples that mitigate or address issue #305.