### PR TITLE
raw_input() is now input() as of Python3

### DIFF
--- a/examples/ad_manager/authentication/generate_refresh_token.py
+++ b/examples/ad_manager/authentication/generate_refresh_token.py
@@ -98,7 +98,7 @@ def main(client_id, client_secret, scopes):
   print('Log into the Google Account you use to access your Ad Manager account'
         'and go to the following URL: \n%s\n' % (auth_url))
   print('After approving the token enter the verification code (if specified).')
-  code = raw_input('Code: ').strip()
+  code = input('Code: ').strip()
 
   try:
     flow.fetch_token(code=code)


### PR DESCRIPTION
Quick change required because I tried to generate a refresh token and realized raw_input() is still in use. Since this repo requires Python 3.6+ this change is necessary.