### PR TITLE
Fix Python3 decode error

### DIFF
--- a/examples/adwords/v201809/advanced_operations/add_responsive_display_ad.py
+++ b/examples/adwords/v201809/advanced_operations/add_responsive_display_ad.py
@@ -113,7 +113,7 @@ def _CreateImage(media_service, opener, url):
     The image that was successfully uploaded.
   """
   # Note: The utf-8 decode is for 2to3 Python 3 compatibility.
-  image_data = opener.open(url).read().decode('utf-8')
+  image_data = opener.open(url).read()
   image = {
       'type': 'IMAGE',
       'data': image_data,


### PR DESCRIPTION
Decoding to utf-8 worked for Python2 but is redundant for Python3 and is code-breaking