### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/ad_manager/v202102/line_item_service/target_custom_criteria.py
+++ b/examples/ad_manager/v202102/line_item_service/target_custom_criteria.py
@@ -42,7 +42,7 @@ def main(client, line_item_id, key_id1, key_id2, key_id3, value_id1, value_id2,
   # Initialize appropriate service.
   line_item_service = client.GetService('LineItemService', version='v202102')
 
-  # create custom criterias
+  # create custom criteria
   custom_criteria1 = {
       'xsi_type': 'CustomCriteria',
       'keyId': key_id1,

--- a/examples/ad_manager/v202105/line_item_service/target_custom_criteria.py
+++ b/examples/ad_manager/v202105/line_item_service/target_custom_criteria.py
@@ -42,7 +42,7 @@ def main(client, line_item_id, key_id1, key_id2, key_id3, value_id1, value_id2,
   # Initialize appropriate service.
   line_item_service = client.GetService('LineItemService', version='v202105')
 
-  # create custom criterias
+  # create custom criteria
   custom_criteria1 = {
       'xsi_type': 'CustomCriteria',
       'keyId': key_id1,

--- a/examples/ad_manager/v202108/line_item_service/target_custom_criteria.py
+++ b/examples/ad_manager/v202108/line_item_service/target_custom_criteria.py
@@ -42,7 +42,7 @@ def main(client, line_item_id, key_id1, key_id2, key_id3, value_id1, value_id2,
   # Initialize appropriate service.
   line_item_service = client.GetService('LineItemService', version='v202108')
 
-  # create custom criterias
+  # create custom criteria
   custom_criteria1 = {
       'xsi_type': 'CustomCriteria',
       'keyId': key_id1,

--- a/examples/adwords/v201809/basic_operations/update_expanded_text_ad.py
+++ b/examples/adwords/v201809/basic_operations/update_expanded_text_ad.py
@@ -53,7 +53,7 @@ def main(client, ad_id):
       'operand': expanded_text_ad
   }]
 
-  # Updates the ad on ther server.
+  # Updates the ad on their server.
   result = ad_service.mutate(operations)
   updated_ad = result['value'][0]
 

--- a/examples/adwords/v201809/extensions/add_prices.py
+++ b/examples/adwords/v201809/extensions/add_prices.py
@@ -17,7 +17,7 @@
 
 """Adds a price extension and associates it with an account.
 
-Campaign targeting is also set usin the specified campaign ID. To get campaigns,
+Campaign targeting is also set using the specified campaign ID. To get campaigns,
 run get_campaigns.py.
 
 The LoadFromStorage method is pulling credentials and properties from a

--- a/googleads/adwords.py
+++ b/googleads/adwords.py
@@ -744,7 +744,7 @@ class BatchJobHelper(object):
           for a single AdWords Service.
         has_prefix: a boolean indicating whether the prefix should be included
           in the request body.
-        has_suffix: a boolean indicating whether the suffic should be included
+        has_suffix: a boolean indicating whether the suffix should be included
           in the request body.
 
       Returns:
@@ -2245,7 +2245,7 @@ class ServiceQueryBuilder(_QueryBuilder):
     """Creates the service query builder with the optionally specified builder.
 
     Creates the service query builder by initializing all attributes including
-    oder by list, start index, and page size.
+    order by list, start index, and page size.
     If the optional query builder are specified, copy all its attributes to this
     instance.
 


### PR DESCRIPTION
There are small typos in:
- examples/ad_manager/v202102/line_item_service/target_custom_criteria.py
- examples/ad_manager/v202105/line_item_service/target_custom_criteria.py
- examples/ad_manager/v202108/line_item_service/target_custom_criteria.py
- examples/adwords/v201809/basic_operations/update_expanded_text_ad.py
- examples/adwords/v201809/extensions/add_prices.py
- googleads/adwords.py

Fixes:
- Should read `criteria` rather than `criterias`.
- Should read `using` rather than `usin`.
- Should read `their` rather than `ther`.
- Should read `suffix` rather than `suffic`.
- Should read `order` rather than `oder`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md