### PR TITLE
allow google-auth dependency up to 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from setuptools import setup
 
 PACKAGES = ['googleads']
 
-DEPENDENCIES = ['google-auth>=1.0.0,<2.0.0',
+DEPENDENCIES = ['google-auth>=1.0.0,<3.0.0',
                 'google-auth-oauthlib>=0.0.1,<1.0.0', 'pytz>=2015.7',
                 'PyYAML>=5.1, <6.0', 'requests>=2.0.0,<3.0.0',
                 'xmltodict>=0.9.2,<1.0.0', 'zeep>=2.5.0']


### PR DESCRIPTION
`google-auth` v2 seems to be compatible with this lib so there is no reason to include this restriction. I haven't tested the integration thoroughly however.

The restriction causes issues when installing this library in a project alongside recent versions of the `google-ads` lib, which requires a newer version of `google-auth` than this lib allows. This causes `pip` to fail to install dependencies due to a constraints violation.

This PR closes #496 .