### PR TITLE
Remove unused dependency:  xmltodict

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,6 @@ This library only supports Python 3.7+.
     - pysocks              -- https://pypi.python.org/pypi/PySocks/
     - pytz                 -- https://pypi.python.org/pypi/pytz
     - pyYAML               -- https://pypi.python.org/pypi/pyYAML/
-    - xmltodict            -- https://pypi.python.org/pypi/xmltodict/
     - zeep                 -- https://pypi.python.org/pypi/zeep
     - mock                 -- https://pypi.python.org/pypi/mock
                               (only needed to run unit tests)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ PACKAGES = ['googleads']
 DEPENDENCIES = ['google-auth>=2.0.0,<3.0.0',
                 'google-auth-oauthlib>=1.0.0,<2.0.0', 'pytz>=2015.7',
                 'PyYAML>=6.0, <7.0', 'requests>=2.0.0,<3.0.0',
-                'xmltodict>=0.9.2,<1.0.0', 'zeep>=2.5.0']
+                'zeep>=2.5.0']
 
 TEST_DEPENDENCIES = ['mock>=2.0.0,<3.0.0', 'pyfakefs>=5.1.0']
 


### PR DESCRIPTION
## Summary

Hello @msaniscalchi,

This pull request removes the unused dependency `xmltodict` from the `setup.py` configuration file. This detection and removal is a finding from ongoing research aimed at identifying and eliminating code bloat within software projects.


## Rationale

The `xmltodict` package was added in e8dea47, and was used in `googleads/adwords.py`. However, this file was later removed, and upon analysis of the codebase, it was found that it is not currently being utilized within the project. Removing this unused dependency can reduce the overall footprint of the application, mitigate potential security risks, and simplify the dependency management process.

## Changes

- Removed the dependency to the `xmltodict`  PyPI package from the `setup.py file.
- Removed the corresponding dependnency requirement from the README.

## Impact

- Reduced package size: The removal of this unused dependency will lead to a decrease in the overall size of the installed packages.
- Simplified dependency tree: Fewer dependencies make the project easier to maintain and can speed up installation.

I have also signed a individual CLA, according to `CONTRIBUTING.md`